### PR TITLE
fix: deployment annotation indentation

### DIFF
--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
 {{- include "oauth2-proxy.labels" . | indent 4 }}
   {{- if .Values.deploymentAnnotations }}
   annotations:
-{{ toYaml .Values.deploymentAnnotations | indent 8 }}
+{{ toYaml .Values.deploymentAnnotations | indent 4 }}
   {{- end }}
   name: {{ template "oauth2-proxy.fullname" . }}
   namespace: {{ template "oauth2-proxy.namespace" $ }}


### PR DESCRIPTION
This pull request includes a small change to the `helm/oauth2-proxy/templates/deployment.yaml` file. The change modifies the indentation level of the `deploymentAnnotations` from 8 spaces to 4 spaces in the `annotations` section of the `metadata`.